### PR TITLE
회원 메뉴 SNS 관리 표시 옵션 추가

### DIFF
--- a/controllers/admin.php
+++ b/controllers/admin.php
@@ -211,6 +211,7 @@ class Admin extends Base
 			'delete_auto_log_record',
 			'sns_services',
 			'sns_profile',
+			'sns_manage',
 			'layout_srl',
 			'skin',
 			'mlayout_srl',

--- a/controllers/eventhandlers.php
+++ b/controllers/eventhandlers.php
@@ -15,7 +15,7 @@ class EventHandlers extends Base
 	 */
 	public function triggerAfterModuleObject()
 	{
-		if ($this->user->isMember())
+		if ($this->user->isMember() && self::getConfig()->sns_manage === 'Y')
 		{
 			MemberController::getInstance()->addMemberMenu('dispSocialloginSnsManage', 'sns_manage');
 		}

--- a/controllers/user.php
+++ b/controllers/user.php
@@ -39,6 +39,11 @@ class User extends Base
 	 */
 	public function dispSocialloginSnsManage()
 	{
+		if (self::getConfig()->sns_manage !== 'Y')
+		{
+			throw new InvalidRequest;
+		}
+
 		if (!Context::get('is_logged'))
 		{
 			throw new Exception('msg_not_logged');

--- a/lang/ko.php
+++ b/lang/ko.php
@@ -51,6 +51,7 @@ $lang->profile = '프로필';
 $lang->profile_name = 'SNS 프로필 닉네임';
 $lang->sns_service = '서비스';
 $lang->about_sns_profile = '회원 팝업메뉴에 SNS 프로필를 추가합니다.';
+$lang->about_sns_manage = '회원 메뉴에 SNS 관리를 추가합니다.';
 $lang->register = '등록';
 $lang->login = '로그인';
 $lang->unknown = '알 수 없음';

--- a/views/setting.html
+++ b/views/setting.html
@@ -35,6 +35,14 @@
 				</label>
 			</div>
 		</div>
+		<div class="x_control-group">
+			<label class="x_control-label" for="sns_manage">{$lang->sns_manage}</label>
+			<div class="x_controls">
+				<label class="x_inline" for="sns_manage">
+					<input type="checkbox" name="sns_manage" id="sns_manage" value="Y" checked="checked"|cond="$config->sns_manage=='Y'" /> {$lang->about_sns_manage}
+				</label>
+			</div>
+		</div>
 	</section>
 	<section class="section">
 		<h1>{$lang->cmd_set_design_info}</h1>


### PR DESCRIPTION
- 회원 메뉴에 SNS 관리 표시를 선택할 수 있게 합니다.
- 단일 SNS만 사용하는 경우 또는 운영 정책상 사용자가 SNS관리 하지 않게 하는 경우 등 관리를 표시 하지 않을 방법이 필요합니다.