### PR TITLE
Fix #11 디스코드 닉네임/아바타가 존재시 사용

### DIFF
--- a/drivers/discord.php
+++ b/drivers/discord.php
@@ -75,8 +75,11 @@ class Discord extends Base
 		// ID, 이름, 프로필 이미지, 프로필 URL
 		$profileValue['email_address'] = $user_info['email'];
 		$profileValue['sns_id'] = $user_info['id'];
-		$profileValue['user_name'] = $user_info['username'];
+		$profileValue['user_name'] = $user_info['global_name'] ?: $user_info['username'];
 		$profileValue['etc'] = $user_info;
+
+		// 프로필 이미지가 있다면 사용
+		if($user_info['avatar']) $profileValue['profile_image'] = "https://cdn.discordapp.com/{$user_info['id']}/{$user_info['avatar']}.png";
 
 		\Rhymix\Modules\Sociallogin\Base::setDriverAuthData('discord', 'profile', $profileValue);
 	}


### PR DESCRIPTION
username은 유저별 고유한 영어 아이디이나 해당 값을 닉네임으로 사용시 한국어권 사이트에서는 대부분 사용성이 떨어지므로 `global_name` 사용이 가능하면 우선 사용하도록 수정했습니다.

추가로 avatar 값이 있다면 역시 사용합니다.