### PR TITLE
네이버 API 요청시 Host 헤더를 설정하지 않음

### DIFF
--- a/drivers/naver.php
+++ b/drivers/naver.php
@@ -225,7 +225,6 @@ class Naver extends Base
 		if ($authorization)
 		{
 			$headers = array(
-				'Host'          => 'apis.naver.com',
 				'Pragma'        => 'no-cache',
 				'Accept'        => '*/*',
 				'Authorization' => 'Bearer ' . $authorization


### PR DESCRIPTION
https://rhymix.org/tip/1909895

API 도메인이 변경되었으나 이전 도메인이 하드코딩되어 있어 문제가 발생합니다.